### PR TITLE
Implement filter testcase

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -16,6 +16,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_PROJECTS_FILTERED_OVERVIEW = "%1$d projects filtered!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
 

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -30,7 +30,7 @@ public class FilterCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+                String.format(Messages.MESSAGE_PROJECTS_FILTERED_OVERVIEW, model.getFilteredPersonList().size()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -2,6 +2,8 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.Arrays;
+
 import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.StudentUnderProjectPredicate;
@@ -25,9 +27,9 @@ public class FilterCommandParser implements Parser<FilterCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
         }
 
-        String projectKeyword = trimmedArgs;
+        String[] projectKeyword = trimmedArgs.split("\\s+");
 
-        return new FilterCommand(new StudentUnderProjectPredicate(projectKeyword));
+        return new FilterCommand(new StudentUnderProjectPredicate(Arrays.asList(projectKeyword)));
     }
 }
 

--- a/src/main/java/seedu/address/model/person/StudentUnderProjectPredicate.java
+++ b/src/main/java/seedu/address/model/person/StudentUnderProjectPredicate.java
@@ -1,24 +1,26 @@
 package seedu.address.model.person;
 
+import java.util.List;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**
- * Tests that a {@code Student}'s {@code Project} matches the keyword given.
+ * Tests that a {@code Student}'s {@code Project} matches any of the keywords given.
  */
 public class StudentUnderProjectPredicate implements Predicate<Person> {
 
-    private final String keyword;
+    private final List<String> keywords;
 
-    public StudentUnderProjectPredicate(String keyword) {
-        this.keyword = keyword;
+    public StudentUnderProjectPredicate(List<String> keywords) {
+        this.keywords = keywords;
     }
 
     @Override
     public boolean test(Person person) {
-        return StringUtil.containsWordIgnoreCase(person.getProject().value, keyword);
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getProject().value, keyword));
     }
 
     @Override
@@ -33,11 +35,11 @@ public class StudentUnderProjectPredicate implements Predicate<Person> {
         }
 
         StudentUnderProjectPredicate otherStudentUnderProjectPredicate = (StudentUnderProjectPredicate) other;
-        return keyword.equals(otherStudentUnderProjectPredicate.keyword);
+        return keywords.equals(otherStudentUnderProjectPredicate.keywords);
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).add("Project", keyword).toString();
+        return new ToStringBuilder(this).add("Project", keywords).toString();
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -1,0 +1,88 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_PROJECTS_FILTERED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.logging.Filter;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.StudentUnderProjectPredicate;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code FilterCommand}.
+ */
+public class FilterCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        StudentUnderProjectPredicate firstPredicate =
+                new StudentUnderProjectPredicate(Collections.singletonList("first"));
+        StudentUnderProjectPredicate secondPredicate =
+                new StudentUnderProjectPredicate(Collections.singletonList("second"));
+
+        FilterCommand filterFirstCommand = new FilterCommand(firstPredicate);
+        FilterCommand filterSecondCommand = new FilterCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(filterFirstCommand.equals(filterFirstCommand));
+
+        // same values -> returns true
+        FilterCommand filterFirstCommandCopy = new FilterCommand(firstPredicate);
+        assertTrue(filterFirstCommand.equals(filterFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(filterFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(filterFirstCommand.equals(null));
+
+        // different project -> returns false
+        assertFalse(filterFirstCommand.equals(filterSecondCommand));
+    }
+
+    @Test
+    public void execute_zeroKeywords_noProjectFound() {
+        String expectedMessage = String.format(MESSAGE_PROJECTS_FILTERED_OVERVIEW, 0);
+        StudentUnderProjectPredicate predicate = preparePredicate(" ");
+        FilterCommand command = new FilterCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleKeywords_multipleProjectsFound() {
+        StudentUnderProjectPredicate predicate = new StudentUnderProjectPredicate(Arrays.asList("keyword"));
+        FilterCommand filterCommand = new FilterCommand(predicate);
+        String expected = FilterCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
+        assertEquals(expected, filterCommand.toString());
+    }
+
+    @Test
+    public void toStringMethod() {
+        StudentUnderProjectPredicate predicate = new StudentUnderProjectPredicate(Arrays.asList("keyword"));
+        FilterCommand filterCommand = new FilterCommand(predicate);
+        String expected = FilterCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
+        assertEquals(expected, filterCommand.toString());
+    }
+
+
+    /**
+     * Parses {@code userInput} into a {@code StudentUnderProjectPredicate} {}
+     */
+    private StudentUnderProjectPredicate preparePredicate(String userInput) {
+        return new StudentUnderProjectPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -9,7 +9,6 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.logging.Filter;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -1,0 +1,32 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FilterCommand;
+import seedu.address.model.person.StudentUnderProjectPredicate;
+
+public class FilterCommandParserTest {
+    private FilterCommandParser parser = new FilterCommandParser();
+
+    @Test
+    public void parse_emptyArgs_throwsParseException() {
+        assertParseFailure(parser, "    ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FilterCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFilterCommand() {
+        FilterCommand expectedFilterCommand =
+                new FilterCommand(new StudentUnderProjectPredicate(Arrays.asList("Project", "Profiler")));
+        assertParseSuccess(parser, "Project Profiler", expectedFilterCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, "\n Project \n \t Profiler \t", expectedFilterCommand);
+    }
+}

--- a/src/test/java/seedu/address/model/person/StudentUnderProjectPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/StudentUnderProjectPredicateTest.java
@@ -1,0 +1,38 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class StudentUnderProjectPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        StudentUnderProjectPredicate firstPredicate = new StudentUnderProjectPredicate(firstPredicateKeywordList);
+        StudentUnderProjectPredicate secondPredicate = new StudentUnderProjectPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same value -> returns true
+        StudentUnderProjectPredicate firstPredicateCopy = new StudentUnderProjectPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false;
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different project -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+}


### PR DESCRIPTION
Fixes #59 
Previous: FilterCommand takes in a single `String` keyword and filter for all projects that contains the given keyword.

Update: FilterCommand now takes in a `List<String>` of keywords. It will filter for all projects that contains at least one of the given keywords.

Add: Implemented testcases for FilterCommand
