### PR TITLE
Handle progress as string

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -50,11 +50,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Project project = ParserUtil.parseProject(argMultimap.getValue(PREFIX_PROJECT).get());
-        int progressValue = argMultimap.getValue(PREFIX_PROGRESS)
-                .map(value -> Integer.parseInt(value))
-                .orElse(0);
-        Progress progress = ParserUtil.parseProgress(progressValue);
-
+        Progress progress = ParserUtil.parseProgress(argMultimap.getValue(PREFIX_PROGRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         Person person = new Person(name, id, phone, email, project, progress, tagList);

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -58,6 +58,7 @@ public class AddCommandParser implements Parser<AddCommand> {
             // If prefix progress is omitted, default to 0.
             progress = ParserUtil.parseProgress("");
         }
+
         Project project = ParserUtil.parseProject(argMultimap.getValue(PREFIX_PROJECT).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -38,19 +38,27 @@ public class AddCommandParser implements Parser<AddCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_ID, PREFIX_PHONE, PREFIX_EMAIL,
                         PREFIX_PROJECT, PREFIX_PROGRESS, PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ID, PREFIX_PROJECT, PREFIX_PROGRESS,
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ID, PREFIX_PROJECT,
                 PREFIX_PHONE, PREFIX_EMAIL) || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_ID, PREFIX_PHONE, PREFIX_EMAIL,
-                PREFIX_PROJECT, PREFIX_PROGRESS);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_ID, PREFIX_PHONE,
+                PREFIX_EMAIL, PREFIX_PROJECT, PREFIX_PROGRESS);
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Id id = ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
+
+        Progress progress; // Initialise progress
+        if (arePrefixesPresent(argMultimap, PREFIX_PROGRESS)) {
+            // If progress prefix found, parse value accordingly.
+            progress = ParserUtil.parseProgress(argMultimap.getValue(PREFIX_PROGRESS).get());
+        } else {
+            // If prefix progress is omitted, default to 0.
+            progress = ParserUtil.parseProgress("");
+        }
         Project project = ParserUtil.parseProject(argMultimap.getValue(PREFIX_PROJECT).get());
-        Progress progress = ParserUtil.parseProgress(argMultimap.getValue(PREFIX_PROGRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         Person person = new Person(name, id, phone, email, project, progress, tagList);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -68,7 +68,7 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         if (argMultimap.getValue(PREFIX_PROGRESS).isPresent()) {
             editPersonDescriptor.setProgress(ParserUtil.parseProgress(
-                    Integer.parseInt(argMultimap.getValue(PREFIX_PROGRESS).get())));
+                   argMultimap.getValue(PREFIX_PROGRESS).get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -98,11 +98,11 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code int progress} into a {@code Progress}.
+     * Parses a {@code String progress} into a {@code Progress}.
      *
      * @throws ParseException if the given {@code progress} is invalid.
      */
-    public static Progress parseProgress(int progress) throws ParseException {
+    public static Progress parseProgress(String progress) throws ParseException {
         requireNonNull(progress);
         if (!Progress.isValidProgress(progress)) {
             throw new ParseException(Progress.MESSAGE_CONSTRAINTS);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -103,8 +103,11 @@ public class ParserUtil {
      * @throws ParseException if the given {@code progress} is invalid.
      */
     public static Progress parseProgress(String progress) throws ParseException {
-        requireNonNull(progress);
-        if (!Progress.isValidProgress(progress)) {
+        if (progress.trim().isEmpty()) {
+            // Call overloaded constructor with progress 0,
+            // if progress prefix not in command
+            return new Progress();
+        } else if (!Progress.isValidProgress(progress)) {
             throw new ParseException(Progress.MESSAGE_CONSTRAINTS);
         }
         return new Progress(progress);

--- a/src/main/java/seedu/address/logic/parser/ProgressCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ProgressCommandParser.java
@@ -36,7 +36,7 @@ public class ProgressCommandParser implements Parser<ProgressCommand> {
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PROGRESS);
         Progress progress = ParserUtil.parseProgress(
-                Integer.parseInt(argMultimap.getValue(PREFIX_PROGRESS).get()));
+                argMultimap.getValue(PREFIX_PROGRESS).get());
 
         return new ProgressCommand(index, progress);
     }

--- a/src/main/java/seedu/address/model/person/Progress.java
+++ b/src/main/java/seedu/address/model/person/Progress.java
@@ -20,7 +20,6 @@ public class Progress {
      *
      * @param progress A valid progress.
      */
-
     public Progress(String progress) {
         requireNonNull(progress);
         checkArgument(isValidProgress(progress), MESSAGE_CONSTRAINTS);

--- a/src/main/java/seedu/address/model/person/Progress.java
+++ b/src/main/java/seedu/address/model/person/Progress.java
@@ -4,15 +4,16 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Person's name in the address book.
+ * Represents a Person's progress a project in Prof-iler.
  * Guarantees: immutable; is valid as declared in {@link #isValidProgress(int)}
  */
 
 public class Progress {
     public static final String MESSAGE_CONSTRAINTS =
-            "Progress should be a number between 0 and 100";
+            "Progress should be a whole number between 0 and 100";
+    public static final String VALIDATION_REGEX = "^(100|[1-9]?[0-9])$";
 
-    public final int value;
+    public final String value;
 
     /**
      * Constructs a {@code Progress}.
@@ -20,7 +21,7 @@ public class Progress {
      * @param progress A valid progress.
      */
 
-    public Progress(int progress) {
+    public Progress(String progress) {
         requireNonNull(progress);
         checkArgument(isValidProgress(progress), MESSAGE_CONSTRAINTS);
         this.value = progress;
@@ -30,27 +31,27 @@ public class Progress {
      * Constructs a {@code Progress} with default value 0
      */
     public Progress() {
-        this.value = 0;
+        this.value = "0";
     }
 
 
     /**
-     * Returns true if a given int is a valid progress.
+     * Returns true if a given String is a valid progress.
      */
-    public static boolean isValidProgress(int test) {
-        return test >= 0 && test <= 100;
+    public static boolean isValidProgress(String test) {
+        return test.matches(VALIDATION_REGEX);
     }
 
     /**
      * Returns value of progress.
      */
-    public int getValue() {
+    public String getValue() {
         return this.value;
     }
 
     @Override
     public String toString() {
-        return Integer.toString(value);
+        return this.value;
     }
 
     @Override
@@ -65,12 +66,12 @@ public class Progress {
         }
 
         Progress otherProgress = (Progress) other;
-        return value == otherProgress.value;
+        return value.equals(otherProgress.value);
     }
 
     @Override
     public int hashCode() {
-        return Integer.hashCode(value);
+        return value.hashCode();
     }
 
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -23,22 +23,22 @@ public class SampleDataUtil {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Id("A0289384P"), new Phone("87438807"),
                     new Email("alexyeoh@example.com"),
-                new Project("Project Orbiting"), new Progress(30),
+                new Project("Project Orbiting"), new Progress("30"),
                 getTagSet("friends")),
             new Person(new Name("Bernice Yu"), new Id("A0214850K"), new Phone("99272758"),
-                new Email("berniceyu@example.com"), new Project("Project ReX"), new Progress(21),
+                new Email("berniceyu@example.com"), new Project("Project ReX"), new Progress("21"),
                 getTagSet("colleagues", "friends")),
             new Person(new Name("Charlotte Oliveiro"), new Id("A0250255M"), new Phone("93210283"),
                 new Email("charlotte@example.com"), new Project("Project Code-desk"), new Progress(),
                 getTagSet("neighbours")),
             new Person(new Name("David Li"), new Id("A0280123C"), new Phone("91031282"),
-                new Email("lidavid@example.com"), new Project("Prof-iler"), new Progress(11),
+                new Email("lidavid@example.com"), new Project("Prof-iler"), new Progress("11"),
                 getTagSet("family")),
             new Person(new Name("Irfan Ibrahim"), new Id("A0267893F"), new Phone("92492021"),
-                new Email("irfan@example.com"), new Project("WealthVault"), new Progress(48),
+                new Email("irfan@example.com"), new Project("WealthVault"), new Progress("48"),
                 getTagSet("classmates")),
             new Person(new Name("Roy Balakrishnan"), new Id("A0280012B"), new Phone("92624417"),
-                new Email("royb@example.com"), new Project("TAssist"), new Progress(17),
+                new Email("royb@example.com"), new Project("TAssist"), new Progress("17"),
                 getTagSet("colleagues"))
         };
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -122,7 +122,7 @@ class JsonAdaptedPerson {
         }
         final Project modelProject = new Project(project);
 
-        if (Integer.valueOf(progress) == null) {
+        if (progress == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     Progress.class.getSimpleName()));
         }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -31,7 +31,7 @@ class JsonAdaptedPerson {
     private final String phone;
     private final String email;
     private final String project;
-    private final int progress;
+    private final String progress;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
 
     /**
@@ -43,7 +43,7 @@ class JsonAdaptedPerson {
             @JsonProperty("phone") String phone,
             @JsonProperty("email") String email,
             @JsonProperty("project") String project,
-            @JsonProperty("progress") int progress,
+            @JsonProperty("progress") String progress,
             @JsonProperty("tags") List<JsonAdaptedTag> tags) {
         this.name = name;
         this.id = id;

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
@@ -4,12 +4,12 @@
     "phone": "9482424",
     "email": "hans@example.com",
     "project": "4th street",
-    "progress": 3
+    "progress": "3"
   }, {
     "name": "Person With Invalid Phone Field",
     "phone": "948asdf2424",
     "email": "hans@example.com",
     "project": "4th street",
-    "progress": 3
+    "progress": "3"
   } ]
 }

--- a/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
@@ -4,6 +4,6 @@
     "phone": "9482424",
     "email": "hans@example.com",
     "project": "4th street",
-    "progres": 50
+    "progress": "50!"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -5,7 +5,7 @@
     "phone": "94351253",
     "email": "alice@example.com",
     "project": "123, Jurong West Ave 6, #08-111",
-    "progress": 50,
+    "progress": "50",
     "tags": [ "friends" ]
   }, {
     "name": "Alice Pauline",
@@ -13,6 +13,6 @@
     "phone": "94351253",
     "email": "pauline@example.com",
     "project": "4th street",
-    "progress": 50
+    "progress": "50"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
@@ -5,6 +5,6 @@
     "phone": "9482424",
     "email": "invalid@email!3e",
     "project": "4th street",
-    "progress": 50
+    "progress": "50"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -6,7 +6,7 @@
     "phone" : "94351253",
     "email" : "alice@example.com",
     "project" : "123, Jurong West Ave 6, #08-111",
-    "progress": 50,
+    "progress": "50",
     "tags" : [ "friends" ]
   }, {
     "name" : "Benson Meier",
@@ -14,7 +14,7 @@
     "phone" : "98765432",
     "email" : "johnd@example.com",
     "project" : "311, Clementi Ave 2, #02-25",
-    "progress": 100,
+    "progress": "100",
     "tags" : [ "owesMoney", "friends" ]
   }, {
     "name" : "Carl Kurz",
@@ -22,7 +22,7 @@
     "phone" : "95352563",
     "email" : "heinz@example.com",
     "project" : "wall street",
-    "progress": 40,
+    "progress": "40",
     "tags" : [ ]
   }, {
     "name" : "Daniel Meier",
@@ -30,7 +30,7 @@
     "phone" : "87652533",
     "email" : "cornelia@example.com",
     "project" : "10th street",
-    "progress": 68,
+    "progress": "68",
     "tags" : [ "friends" ]
   }, {
     "name" : "Elle Meyer",
@@ -38,7 +38,7 @@
     "phone" : "9482224",
     "email" : "werner@example.com",
     "project" : "michegan ave",
-    "progress": 32,
+    "progress": "32",
     "tags" : [ ]
   }, {
     "name" : "Fiona Kunz",
@@ -46,7 +46,7 @@
     "phone" : "9482427",
     "email" : "lydia@example.com",
     "project" : "little tokyo",
-    "progress": 22,
+    "progress": "22",
     "tags" : [ ]
   }, {
     "name" : "George Best",
@@ -54,7 +54,7 @@
     "phone" : "9482442",
     "email" : "anna@example.com",
     "project" : "4th street",
-    "progress": 10,
+    "progress": "10",
     "tags" : [ ]
   } ]
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -40,8 +40,8 @@ public class CommandTestUtil {
     public static final String VALID_PROJECT_AMY = "Project Amy-cable";
     public static final String VALID_PROJECT_BOB = "Project Bob-B";
 
-    public static final int VALID_PROGRESS_AMY = 78;
-    public static final int VALID_PROGRESS_BOB = 38;
+    public static final String VALID_PROGRESS_AMY = "78";
+    public static final String VALID_PROGRESS_BOB = "38";
 
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -39,25 +39,37 @@ public class CommandTestUtil {
     public static final String VALID_EMAIL_BOB = "bob@example.com";
     public static final String VALID_PROJECT_AMY = "Project Amy-cable";
     public static final String VALID_PROJECT_BOB = "Project Bob-B";
-
     public static final String VALID_PROGRESS_AMY = "78";
     public static final String VALID_PROGRESS_BOB = "38";
+    public static final String VALID_NAME_IDA = "Ida Mueller";
+    public static final String VALID_ID_IDA = "A7283937J";
+    public static final String VALID_PHONE_IDA = "8482131";
+    public static final String VALID_EMAIL_IDA = "hans@example.com";
+    public static final String VALID_PROJECT_IDA = "chicago ave";
+    public static final String VALID_PROGRESS_IDA = "0";
+
 
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
+    public static final String NAME_DESC_IDA = " " + PREFIX_NAME + VALID_NAME_IDA;
     public static final String ID_DESC_AMY = " " + PREFIX_ID + VALID_ID_AMY;
     public static final String ID_DESC_BOB = " " + PREFIX_ID + VALID_ID_BOB;
+    public static final String ID_DESC_IDA = " " + PREFIX_ID + VALID_ID_IDA;
     public static final String PHONE_DESC_AMY = " " + PREFIX_PHONE + VALID_PHONE_AMY;
     public static final String PHONE_DESC_BOB = " " + PREFIX_PHONE + VALID_PHONE_BOB;
+    public static final String PHONE_DESC_IDA = " " + PREFIX_PHONE + VALID_PHONE_IDA;
     public static final String EMAIL_DESC_AMY = " " + PREFIX_EMAIL + VALID_EMAIL_AMY;
     public static final String EMAIL_DESC_BOB = " " + PREFIX_EMAIL + VALID_EMAIL_BOB;
+    public static final String EMAIL_DESC_IDA = " " + PREFIX_EMAIL + VALID_EMAIL_IDA;
     public static final String PROJECT_DESC_AMY = " " + PREFIX_PROJECT + VALID_PROJECT_AMY;
     public static final String PROJECT_DESC_BOB = " " + PREFIX_PROJECT + VALID_PROJECT_BOB;
+    public static final String PROJECT_DESC_IDA = " " + PREFIX_PROJECT + VALID_PROJECT_IDA;
     public static final String PROGRESS_DESC_AMY = " " + PREFIX_PROGRESS + VALID_PROGRESS_AMY;
     public static final String PROGRESS_DESC_BOB = " " + PREFIX_PROGRESS + VALID_PROGRESS_BOB;
+    public static final String PROGRESS_DESC_IDA = " " + PREFIX_PROGRESS + VALID_PROGRESS_IDA;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
@@ -66,8 +78,9 @@ public class CommandTestUtil {
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_PROJECT_DESC = " " + PREFIX_PROJECT; // empty string not allowed for projects
+    // progress needs to be between 0 and 100
     public static final String INVALID_PROGRESS_DESC = " " + PREFIX_PROGRESS + 101;
-    //empty string not allowed for progress
+
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -3,8 +3,10 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_IDA;
 import static seedu.address.logic.commands.CommandTestUtil.ID_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ID_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.ID_DESC_IDA;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ID_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
@@ -14,14 +16,17 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_PROJECT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_IDA;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_IDA;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.PROGRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PROGRESS_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PROJECT_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PROJECT_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PROJECT_DESC_IDA;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
@@ -41,6 +46,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalPersons.AMY;
 import static seedu.address.testutil.TypicalPersons.BOB;
+import static seedu.address.testutil.TypicalPersons.IDA;
 
 import org.junit.jupiter.api.Test;
 
@@ -172,6 +178,12 @@ public class AddCommandParserTest {
         Person expectedPerson = new PersonBuilder(AMY).withTags().build();
         assertParseSuccess(parser, NAME_DESC_AMY + ID_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
                 + PROJECT_DESC_AMY + PROGRESS_DESC_AMY, new AddCommand(expectedPerson));
+
+        // progress omitted
+        Person expectedIdaPerson = new PersonBuilder(IDA).withTags().build();
+        assertParseSuccess(parser, NAME_DESC_IDA + ID_DESC_IDA + PHONE_DESC_IDA + EMAIL_DESC_IDA
+                + PROJECT_DESC_IDA, new AddCommand(expectedIdaPerson));
+
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -28,14 +28,14 @@ public class ParserUtilTest {
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
-    private static final int INVALID_PROGRESS = 101;
+    private static final String INVALID_PROGRESS = "101";
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_ID = "A0263737F";
     private static final String VALID_PHONE = "123456";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
-    private static final int VALID_PROGRESS = 50;
+    private static final String VALID_PROGRESS = "50";
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
@@ -156,7 +156,7 @@ public class ParserUtilTest {
 
     @Test
     public void parseProgress_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> ParserUtil.parseProgress((Integer) null));
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseProgress((String) null));
     }
 
     @Test
@@ -174,7 +174,7 @@ public class ParserUtilTest {
     public void parseProgress_validValueWithWhitespace_returnsTrimmedProgress() throws Exception {
         String progressWithWhitespace = WHITESPACE + VALID_PROGRESS + WHITESPACE;
         Progress expectedProgress = new Progress(VALID_PROGRESS);
-        assertEquals(expectedProgress, ParserUtil.parseProgress(Integer.parseInt(progressWithWhitespace.trim())));
+        assertEquals(expectedProgress, ParserUtil.parseProgress(progressWithWhitespace.trim()));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -178,6 +178,20 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseProgress_emptyString_returnsZeroProgress() throws Exception {
+        String emptyString = "";
+        Progress expectedProgress = new Progress();
+        assertEquals(expectedProgress, ParserUtil.parseProgress(emptyString));
+    }
+
+    @Test
+    public void parseProgress_emptyStringWithWhitespace_returnsZeroProgress() throws Exception {
+        String emptyString = WHITESPACE + "" + WHITESPACE + "" + WHITESPACE;
+        Progress expectedProgress = new Progress();
+        assertEquals(expectedProgress, ParserUtil.parseProgress(emptyString));
+    }
+
+    @Test
     public void parseEmail_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> ParserUtil.parseEmail((String) null));
     }

--- a/src/test/java/seedu/address/model/person/ProgressTest.java
+++ b/src/test/java/seedu/address/model/person/ProgressTest.java
@@ -12,32 +12,32 @@ public class ProgressTest {
     @Test
     public void constructor_void_setsProgressToZero() {
         Progress progress = new Progress();
-        assertEquals(0, progress.getValue());
+        assertEquals("0", progress.getValue());
     }
 
     @Test
     public void constructor_invalidProgress_throwsIllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class, () -> new Progress(Integer.parseInt(" ")));
-        assertThrows(IllegalArgumentException.class, () -> new Progress(Integer.parseInt("abc")));
-        assertThrows(IllegalArgumentException.class, () -> new Progress(Integer.parseInt("123")));
-        assertThrows(IllegalArgumentException.class, () -> new Progress(Integer.parseInt("123ab45")));
+        assertThrows(IllegalArgumentException.class, () -> new Progress(" "));
+        assertThrows(IllegalArgumentException.class, () -> new Progress("abc"));
+        assertThrows(IllegalArgumentException.class, () -> new Progress("123"));
+        assertThrows(IllegalArgumentException.class, () -> new Progress("123ab45"));
     }
 
     @Test
     public void isValidProgress() {
         // valid addresses
-        assertTrue(Progress.isValidProgress(32));
-        assertTrue(Progress.isValidProgress(100));
-        assertTrue(Progress.isValidProgress(0));
+        assertTrue(Progress.isValidProgress("32"));
+        assertTrue(Progress.isValidProgress("100"));
+        assertTrue(Progress.isValidProgress("0"));
 
     }
 
     @Test
     public void equals() {
-        Progress progress = new Progress(75);
+        Progress progress = new Progress("75");
 
         // same values -> returns true
-        assertTrue(progress.equals(new Progress(75)));
+        assertTrue(progress.equals(new Progress("75")));
 
         // same object -> returns true
         assertTrue(progress.equals(progress));
@@ -49,7 +49,7 @@ public class ProgressTest {
         assertFalse(progress.equals("hi"));
 
         // different values -> returns false
-        assertFalse(progress.equals(new Progress(76)));
+        assertFalse(progress.equals(new Progress("76")));
     }
 
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -58,7 +58,8 @@ public class JsonAdaptedPersonTest {
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_ID, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_PROGRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_ID, VALID_PHONE, VALID_EMAIL,
+                VALID_ADDRESS, VALID_PROGRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -124,14 +125,16 @@ public class JsonAdaptedPersonTest {
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_ID, VALID_PHONE, VALID_EMAIL, null, VALID_PROGRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_ID,
+                VALID_PHONE, VALID_EMAIL, null, VALID_PROGRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Project.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidProgress_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_ID, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, INVALID_PROGRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_ID,
+                VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, INVALID_PROGRESS, VALID_TAGS);
         String expectedMessage = Progress.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -26,7 +26,7 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
 
-    private static final int INVALID_PROGRESS = 101;
+    private static final String INVALID_PROGRESS = "101";
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = BENSON.getName().toString();
@@ -51,15 +51,14 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_NAME, VALID_ID, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        Integer.parseInt(VALID_PROGRESS), VALID_TAGS);
+                        VALID_PROGRESS, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_ID, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                Integer.parseInt(VALID_PROGRESS), VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_ID, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_PROGRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -67,7 +66,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidId_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, INVALID_ID, VALID_PHONE, VALID_EMAIL,
-                VALID_ADDRESS, Integer.parseInt(VALID_PROGRESS), VALID_TAGS);
+                VALID_ADDRESS, VALID_PROGRESS, VALID_TAGS);
         String expectedMessage = Id.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -75,7 +74,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullId_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                Integer.parseInt(VALID_PROGRESS), VALID_TAGS);
+                VALID_PROGRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Id.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -84,7 +83,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_ID, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        Integer.parseInt(VALID_PROGRESS), VALID_TAGS);
+                        VALID_PROGRESS, VALID_TAGS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -92,7 +91,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_ID, null, VALID_EMAIL,
-                VALID_ADDRESS, Integer.parseInt(VALID_PROGRESS), VALID_TAGS);
+                VALID_ADDRESS, VALID_PROGRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -101,7 +100,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_ID, VALID_PHONE, INVALID_EMAIL,
-                        VALID_ADDRESS, Integer.parseInt(VALID_PROGRESS), VALID_TAGS);
+                        VALID_ADDRESS, VALID_PROGRESS, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -110,7 +109,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_ID,
                 VALID_PHONE, null, VALID_ADDRESS,
-                Integer.parseInt(VALID_PROGRESS), VALID_TAGS);
+                VALID_PROGRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -118,23 +117,21 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_ID, VALID_PHONE, VALID_EMAIL,
-                INVALID_ADDRESS, Integer.parseInt(VALID_PROGRESS), VALID_TAGS);
+                INVALID_ADDRESS, VALID_PROGRESS, VALID_TAGS);
         String expectedMessage = Project.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_ID, VALID_PHONE, VALID_EMAIL, null,
-                Integer.parseInt(VALID_PROGRESS), VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_ID, VALID_PHONE, VALID_EMAIL, null, VALID_PROGRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Project.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidProgress_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_ID, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                INVALID_PROGRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_ID, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, INVALID_PROGRESS, VALID_TAGS);
         String expectedMessage = Progress.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -145,7 +142,7 @@ public class JsonAdaptedPersonTest {
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_ID, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        Integer.parseInt(VALID_PROGRESS), invalidTags);
+                        VALID_PROGRESS, invalidTags);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -86,7 +86,7 @@ public class EditPersonDescriptorBuilder {
     /**
      * Sets the {@code Progress} of the {@code EditPersonDescriptor} that we are building.
      */
-    public EditPersonDescriptorBuilder withProgress(int progress) {
+    public EditPersonDescriptorBuilder withProgress(String progress) {
         descriptor.setProgress(new Progress(progress));
         return this;
     }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -93,7 +93,7 @@ public class PersonBuilder {
     /**
      * Sets the {@code Progress} of the {@code Person} that we are building.
      */
-    public PersonBuilder withProgress(int progress) {
+    public PersonBuilder withProgress(String progress) {
         this.progress = new Progress(progress);
         return this;
     }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -29,25 +29,25 @@ public class TypicalPersons {
 
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withId("A0284716F").withProject("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
-            .withProgress(50).withPhone("94351253").withTags("friends").build();
+            .withProgress("50").withPhone("94351253").withTags("friends").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withId("A9472937S").withProject("311, Clementi Ave 2, #02-25").withEmail("johnd@example.com")
-            .withPhone("98765432").withProgress(100).withTags("owesMoney", "friends").build();
+            .withPhone("98765432").withProgress("100").withTags("owesMoney", "friends").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withId("A0285516F")
-            .withPhone("95352563").withEmail("heinz@example.com").withProject("wall street").withProgress(40).build();
+            .withPhone("95352563").withEmail("heinz@example.com").withProject("wall street").withProgress("40").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withId("A0128588N")
             .withPhone("87652533").withEmail("cornelia@example.com")
-            .withProject("10th street").withProgress(68).withTags("friends").build();
+            .withProject("10th street").withProgress("68").withTags("friends").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withId("A0778839G")
-            .withPhone("9482224").withEmail("werner@example.com").withProject("michegan ave").withProgress(32).build();
+            .withPhone("9482224").withEmail("werner@example.com").withProject("michegan ave").withProgress("32").build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withId("A0284736H")
-            .withPhone("9482427").withEmail("lydia@example.com").withProgress(22).withProject("little tokyo").build();
+            .withPhone("9482427").withEmail("lydia@example.com").withProgress("22").withProject("little tokyo").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withId("A0028152D")
-            .withPhone("9482442").withProgress(10).withEmail("anna@example.com").withProject("4th street").build();
+            .withPhone("9482442").withProgress("10").withEmail("anna@example.com").withProject("4th street").build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withId("A0012212D")
-            .withPhone("8482424").withEmail("stefan@example.com").withProject("little india").withProgress(30).build();
+            .withPhone("8482424").withEmail("stefan@example.com").withProject("little india").withProgress("30").build();
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withId("A7283937J")
             .withPhone("8482131").withEmail("hans@example.com").withProject("chicago ave").build();
 

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -49,7 +49,7 @@ public class TypicalPersons {
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withId("A0012212D")
             .withPhone("8482424").withEmail("stefan@example.com").withProject("little india").withProgress("30").build();
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withId("A7283937J")
-            .withPhone("8482131").withEmail("hans@example.com").withProject("chicago ave").build();
+            .withPhone("8482131").withEmail("hans@example.com").withProject("chicago ave").withProgress("69").build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withId(VALID_ID_AMY)

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -50,8 +50,8 @@ public class TypicalPersons {
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier")
             .withId("A0012212D").withPhone("8482424").withEmail("stefan@example.com")
             .withProject("little india").withProgress("30").build();
-    public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withId("A7283937J")
-            .withPhone("8482131").withEmail("hans@example.com").withProject("chicago ave").withProgress("69").build();
+    public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withId("A7283937J").withProgress("0")
+            .withPhone("8482131").withEmail("hans@example.com").withProject("chicago ave").build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withId(VALID_ID_AMY)

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -39,15 +39,17 @@ public class TypicalPersons {
             .withPhone("87652533").withEmail("cornelia@example.com")
             .withProject("10th street").withProgress("68").withTags("friends").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withId("A0778839G")
-            .withPhone("9482224").withEmail("werner@example.com").withProject("michegan ave").withProgress("32").build();
+            .withPhone("9482224").withEmail("werner@example.com")
+            .withProject("michegan ave").withProgress("32").build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withId("A0284736H")
             .withPhone("9482427").withEmail("lydia@example.com").withProgress("22").withProject("little tokyo").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withId("A0028152D")
             .withPhone("9482442").withProgress("10").withEmail("anna@example.com").withProject("4th street").build();
 
     // Manually added
-    public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withId("A0012212D")
-            .withPhone("8482424").withEmail("stefan@example.com").withProject("little india").withProgress("30").build();
+    public static final Person HOON = new PersonBuilder().withName("Hoon Meier")
+            .withId("A0012212D").withPhone("8482424").withEmail("stefan@example.com")
+            .withProject("little india").withProgress("30").build();
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withId("A7283937J")
             .withPhone("8482131").withEmail("hans@example.com").withProject("chicago ave").withProgress("69").build();
 


### PR DESCRIPTION
Fixes #87 

Fixed issue where progress prefix cannot be omitted, now it successfully defaults to 0 when omitted.

Currrently Progress has an overloaded constructor to create progress with 0, so current implementation is:

AddCommandParser.java - I check If prefix progress is omitted, default to 0, which calls ParserUtil#parseProgress, which then calls the overloaded constructor. 

Would it be better to omit the overloaded constructor, and just add a field in AddCommandParser to parse string "0"? What do yall think?


Edit: will add tests soon